### PR TITLE
Add License and License URI parsing

### DIFF
--- a/parse-readme.php
+++ b/parse-readme.php
@@ -90,8 +90,22 @@ Class WordPress_Readme_Parser {
 			$donate_link = NULL;
 
 
+		// License: GPLv2 or later
+		if ( preg_match('|License:(.*)|i', $file_contents, $_license) )
+			$license = $this->sanitize_text( $_license[1] );
+		else
+			$license = NULL;
+
+
+		// License URI: URL
+		if ( preg_match('|License URI:(.*)|i', $file_contents, $_license_uri) )
+			$license_uri = esc_url( $_license_uri[1] );
+		else
+			$license_uri = NULL;
+
+
 		// togs, conts, etc are optional and order shouldn't matter.  So we chop them only after we've grabbed their values.
-		foreach ( array('tags', 'contributors', 'requires_at_least', 'tested_up_to', 'stable_tag', 'donate_link') as $chop ) {
+		foreach ( array('tags', 'contributors', 'requires_at_least', 'tested_up_to', 'stable_tag', 'donate_link', 'license', 'license_uri') as $chop ) {
 			if ( $$chop ) {
 				$_chop = '_' . $chop;
 				$file_contents = $this->chop_string( $file_contents, ${$_chop}[0] );
@@ -192,6 +206,8 @@ Class WordPress_Readme_Parser {
 			'stable_tag' => $stable_tag,
 			'contributors' => $contributors,
 			'donate_link' => $donate_link,
+			'license' => $license,
+			'license_uri' => $license_uri,
 			'short_description' => $short_description,
 			'screenshots' => $final_screenshots,
 			'is_excerpt' => $excerpt,

--- a/validator.php
+++ b/validator.php
@@ -26,6 +26,10 @@ function validate_readme($r) {
 		$warnings[] = 'No <code>== Description ==</code> section was found... your short description section will be used instead';
 	if ( $r['is_truncated'] )
 		$warnings[] = 'Your short description exceeds the 150 character limit';
+	if ( !$r['license'] )
+		$warnings[] = 'No <code>License</code> specified';
+	if ( !$r['license_uri'] )
+		$warnings[] = 'No <code>License URI</code> specified';
 
 
 	// notes
@@ -88,7 +92,9 @@ function validate_readme($r) {
 	<strong>Tags:</strong> <?php echo implode(', ', $r['tags']);?><br />
 	<strong>Requires at least:</strong> <?php echo $r['requires_at_least']; ?><br />
 	<strong>Tested up to:</strong> <?php echo $r['tested_up_to']; ?><br />
-	<strong>Stable tag:</strong> <?php echo $r['stable_tag']; ?>
+	<strong>Stable tag:</strong> <?php echo $r['stable_tag']; ?><br />
+	<strong>License:</strong> <?php echo $r['license']; ?><br />
+	<strong>License URI:</strong> <?php echo $r['license_uri']; ?>
 	</p>
 
 	<hr />


### PR DESCRIPTION
The License and License URI wasn't chopped and ended up in short_description. http://wp.me/p29geH-7
