### PR TITLE
Fixed: "Notice: Undefined variable: upgrade_notice ... "

### DIFF
--- a/parse-readme.php
+++ b/parse-readme.php
@@ -154,8 +154,8 @@ Class WordPress_Readme_Parser {
 
 		// Parse the upgrade_notice section specially:
 		// 1.0 => blah, 1.1 => fnord
+    $upgrade_notice = array();
 		if ( isset($final_sections['upgrade_notice']) ) {
-			$upgrade_notice = array();
 			$split = preg_split( '#<h4>(.*?)</h4>#', $final_sections['upgrade_notice'], -1, PREG_SPLIT_DELIM_CAPTURE | PREG_SPLIT_NO_EMPTY );
 			for ( $i = 0; $i < count( $split ); $i += 2 )
 				$upgrade_notice[$this->sanitize_text( $split[$i] )] = substr( $this->sanitize_text( $split[$i + 1] ), 0, 300 );
@@ -264,7 +264,7 @@ Class WordPress_Readme_Parser {
 		);
 
 		$text = balanceTags($text);
-		
+
 		$text = wp_kses( $text, $allowed );
 		$text = trim($text);
 		return $text;

--- a/parse-readme.php
+++ b/parse-readme.php
@@ -89,9 +89,21 @@ Class WordPress_Readme_Parser {
 		else
 			$donate_link = NULL;
 
+		// License: Type
+		if ( preg_match('|License:(.*)|i', $file_contents, $_license) )
+			$license = $this->sanitize_text( $_license[1] );
+		else
+      $license = NULL;
+
+		// License URI: URI
+		if ( preg_match('|License URI:(.*)|i', $file_contents, $_license_uri) )
+			$license_uri = esc_url( $_license_uri[1] );
+		else
+      $license_uri = NULL;
+
 
 		// togs, conts, etc are optional and order shouldn't matter.  So we chop them only after we've grabbed their values.
-		foreach ( array('tags', 'contributors', 'requires_at_least', 'tested_up_to', 'stable_tag', 'donate_link') as $chop ) {
+		foreach ( array('tags', 'contributors', 'requires_at_least', 'tested_up_to', 'stable_tag', 'donate_link', 'license', 'license_uri') as $chop ) {
 			if ( $$chop ) {
 				$_chop = '_' . $chop;
 				$file_contents = $this->chop_string( $file_contents, ${$_chop}[0] );
@@ -191,7 +203,9 @@ Class WordPress_Readme_Parser {
 			'tested_up_to' => $tested_up_to,
 			'stable_tag' => $stable_tag,
 			'contributors' => $contributors,
-			'donate_link' => $donate_link,
+      'donate_link' => $donate_link,
+      'license' => $license,
+      'license_uri' => $license_uri,
 			'short_description' => $short_description,
 			'screenshots' => $final_screenshots,
 			'is_excerpt' => $excerpt,


### PR DESCRIPTION
The variable `$upgrade_notice` is never initialized if there is no upgrade notice section which is the case with v1.0 plugins, so it throws the following error:

> `Notice: Undefined variable: upgrade_notice in`
> `/Users/mikeschinkel/Tools/wppm/src/readme-parser/parse-readme.php on line 202`

This patch simply moves the initialization of  `$upgrade_notice` from inside the `if( ... ) { ... }` to just before it.
